### PR TITLE
Allow and truncate big tags in atomic's fetch_*

### DIFF
--- a/src/atomic.rs
+++ b/src/atomic.rs
@@ -496,7 +496,8 @@ impl<T> Atomic<T> {
     /// Bitwise "and" with the current tag.
     ///
     /// Performs a bitwise "and" operation on the current tag and the argument `val`, and sets the
-    /// new tag to the result. Returns the previous pointer.
+    /// new tag to the result. Returns the previous pointer.  Before the operation, `val` is
+    /// truncated to be fit in the bitmask returned by [`tag_bits()`](fn.tag_bits.html)).
     ///
     /// This method takes an [`Ordering`] argument which describes the memory ordering of this
     /// operation.
@@ -522,7 +523,8 @@ impl<T> Atomic<T> {
     /// Bitwise "or" with the current tag.
     ///
     /// Performs a bitwise "or" operation on the current tag and the argument `val`, and sets the
-    /// new tag to the result. Returns the previous pointer.
+    /// new tag to the result. Returns the previous pointer.  Before the operation, `val` is
+    /// truncated to be fit in the bitmask returned by [`tag_bits()`](fn.tag_bits.html)).
     ///
     /// This method takes an [`Ordering`] argument which describes the memory ordering of this
     /// operation.
@@ -548,7 +550,8 @@ impl<T> Atomic<T> {
     /// Bitwise "xor" with the current tag.
     ///
     /// Performs a bitwise "xor" operation on the current tag and the argument `val`, and sets the
-    /// new tag to the result. Returns the previous pointer.
+    /// new tag to the result. Returns the previous pointer.  Before the operation, `val` is
+    /// truncated to be fit in the bitmask returned by [`tag_bits()`](fn.tag_bits.html)).
     ///
     /// This method takes an [`Ordering`] argument which describes the memory ordering of this
     /// operation.

--- a/src/atomic.rs
+++ b/src/atomic.rs
@@ -71,18 +71,6 @@ fn ensure_aligned<T>(raw: *const T) {
     assert_eq!(raw as usize & low_bits::<T>(), 0, "unaligned pointer");
 }
 
-/// Panics if the tag doesn't fit into the unused bits of an aligned pointer to `T`.
-#[inline]
-fn validate_tag<T>(tag: usize) {
-    let mask = low_bits::<T>();
-    assert!(
-        tag <= mask,
-        "tag too large to fit into the unused bits: {} > {}",
-        tag,
-        mask
-    );
-}
-
 /// Returns a bitmask containing the unused least significant bits of an aligned pointer to `T`.
 #[inline]
 fn low_bits<T>() -> usize {
@@ -708,7 +696,8 @@ impl<T> Owned<T> {
         self.data & low_bits::<T>()
     }
 
-    /// Returns the same pointer, but tagged with `tag`.
+    /// Returns the same pointer, but tagged with `tag`. `tag` is truncated to be fit into the
+    /// unused bits of the pointer to `T`.
     ///
     /// # Examples
     ///
@@ -978,7 +967,8 @@ impl<'scope, T> Ptr<'scope, T> {
         self.data & low_bits::<T>()
     }
 
-    /// Returns the same pointer, but tagged with `tag`.
+    /// Returns the same pointer, but tagged with `tag`. `tag` is truncated to be fit into the
+    /// unused bits of the pointer to `T`.
     ///
     /// # Examples
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,6 @@ mod epoch;
 mod global;
 mod sync;
 
-pub use self::atomic::{Atomic, CompareAndSetOrdering, Owned, Ptr, tag_bits};
+pub use self::atomic::{Atomic, CompareAndSetOrdering, Owned, Ptr};
 pub use self::global::{pin, is_pinned};
 pub use self::mutator::{Scope, unprotected};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,6 @@ mod epoch;
 mod global;
 mod sync;
 
-pub use self::atomic::{Atomic, CompareAndSetOrdering, Owned, Ptr};
+pub use self::atomic::{Atomic, CompareAndSetOrdering, Owned, Ptr, tag_bits};
 pub use self::global::{pin, is_pinned};
 pub use self::mutator::{Scope, unprotected};


### PR DESCRIPTION
Currently, `fetch_add`, `fetch_or`, `fetch_xor` for atomics require that the pointer tags are fit in the unused bits in a pointer.  However, this may be too restrictive for users, as evidenced by the use of big tags in @stjepang's `channel` (https://github.com/stjepang/channel/blob/master/src/flavors/list.rs#L102).

This PR allows big tags, but truncate them before actually using them, as `coco` does (https://github.com/stjepang/coco/blob/master/src/epoch/atomic.rs#L429).  In order for the user to be able to check if their tags are fit in the unused bits, we export the `tag_bits()` function that lets you know which bits are usable in tags.

This PR is currently not `cargo test`able.  But I manually tested it on top of #5, and it worked fine.  Also, `channel`'s `cargo test` also worked fine: https://github.com/jeehoonkang/channel/tree/crossbeam-epoch

Closes #6