### PR TITLE
Update the implementation of unprotected scope

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,5 +46,5 @@ mod global;
 mod sync;
 
 pub use self::atomic::{Atomic, CompareAndSetOrdering, Owned, Ptr};
-pub use self::global::{pin, is_pinned, unprotected};
-pub use self::mutator::Scope;
+pub use self::mutator::{Scope, unprotected};
+pub use self::global::{pin, is_pinned};


### PR DESCRIPTION
This is a subset of RFC #10 (https://github.com/crossbeam-rs/rfcs/pull/10).  It doesn't change any interface, so I would like to post this PR without going for RFC.

In short, it implements @stjepang 's suggestion (https://github.com/crossbeam-rs/rfcs/pull/10#issuecomment-327125792): `unprotected` scope has a null bag, and garbages created within this scope are immediately disposed of.