### PR TITLE
Implement default_handle()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,5 +74,5 @@ mod sync;
 
 pub use self::atomic::{Atomic, CompareAndSetOrdering, Owned, Ptr};
 pub use self::scope::{Scope, unprotected};
-pub use self::default::{pin, is_pinned};
+pub use self::default::{default_handle, pin, is_pinned};
 pub use self::collector::{Collector, Handle};


### PR DESCRIPTION
Closes #25 

`default_handle()` is unsafe because when it is called in another TLS object's `drop()`, `HANDLE` may have already been dropped.