### PR TITLE
Rename into_ptr into into_shared

### DIFF
--- a/benches/defer.rs
+++ b/benches/defer.rs
@@ -12,7 +12,7 @@ use utils::scoped::scope;
 fn single_alloc_defer_free(b: &mut Bencher) {
     b.iter(|| {
         let guard = &epoch::pin();
-        let p = Owned::new(1).into_ptr(guard);
+        let p = Owned::new(1).into_shared(guard);
         unsafe {
             guard.defer(move || p.into_owned());
         }
@@ -40,7 +40,7 @@ fn multi_alloc_defer_free(b: &mut Bencher) {
                 s.spawn(|| {
                     for _ in 0..STEPS {
                         let guard = &epoch::pin();
-                        let p = Owned::new(1).into_ptr(guard);
+                        let p = Owned::new(1).into_shared(guard);
                         unsafe {
                             guard.defer(move || p.into_owned());
                         }

--- a/src/atomic.rs
+++ b/src/atomic.rs
@@ -620,11 +620,11 @@ impl<T> Owned<T> {
     ///
     /// let o = Owned::new(1234);
     /// let guard = &epoch::pin();
-    /// let p = o.into_ptr(guard);
+    /// let p = o.into_shared(guard);
     /// ```
     ///
     /// [`Shared`]: struct.Shared.html
-    pub fn into_ptr<'g>(self, _: &'g Guard) -> Shared<'g, T> {
+    pub fn into_shared<'g>(self, _: &'g Guard) -> Shared<'g, T> {
         unsafe { Shared::from_data(self.into_data()) }
     }
 

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -125,7 +125,7 @@ mod tests {
         for _ in 0..100 {
             let guard = &handle.pin();
             unsafe {
-                let a = Owned::new(7).into_ptr(guard);
+                let a = Owned::new(7).into_shared(guard);
                 guard.defer(move || a.into_owned());
 
                 assert!(!(*(*guard.local).bag.get()).is_empty());
@@ -146,7 +146,7 @@ mod tests {
         let guard = &handle.pin();
         unsafe {
             for _ in 0..10 {
-                let a = Owned::new(7).into_ptr(guard);
+                let a = Owned::new(7).into_shared(guard);
                 guard.defer(move || a.into_owned());
             }
             assert!(!(*(*guard.local).bag.get()).is_empty());
@@ -193,7 +193,7 @@ mod tests {
         unsafe {
             let guard = &handle.pin();
             for _ in 0..COUNT {
-                let a = Owned::new(7i32).into_ptr(guard);
+                let a = Owned::new(7i32).into_shared(guard);
                 guard.defer(move || {
                     drop(a.into_owned());
                     DESTROYS.fetch_add(1, Ordering::Relaxed);
@@ -226,7 +226,7 @@ mod tests {
         unsafe {
             let guard = &handle.pin();
             for _ in 0..COUNT {
-                let a = Owned::new(7i32).into_ptr(guard);
+                let a = Owned::new(7i32).into_shared(guard);
                 guard.defer(move || {
                     drop(a.into_owned());
                     DESTROYS.fetch_add(1, Ordering::Relaxed);
@@ -268,7 +268,7 @@ mod tests {
             let guard = &handle.pin();
 
             for _ in 0..COUNT {
-                let a = Owned::new(Elem(7i32)).into_ptr(guard);
+                let a = Owned::new(Elem(7i32)).into_shared(guard);
                 guard.defer(move || a.into_owned());
             }
             guard.flush();
@@ -293,7 +293,7 @@ mod tests {
             let guard = &handle.pin();
 
             for _ in 0..COUNT {
-                let a = Owned::new(7i32).into_ptr(guard);
+                let a = Owned::new(7i32).into_shared(guard);
                 guard.defer(move || {
                     drop(a.into_owned());
                     DESTROYS.fetch_add(1, Ordering::Relaxed);
@@ -333,7 +333,7 @@ mod tests {
                 v.push(Elem(i as i32));
             }
 
-            let a = Owned::new(v).into_ptr(guard);
+            let a = Owned::new(v).into_shared(guard);
             guard.defer(move || a.into_owned());
             guard.flush();
         }
@@ -403,7 +403,7 @@ mod tests {
                         for _ in 0..COUNT {
                             let guard = &handle.pin();
                             unsafe {
-                                let a = Owned::new(Elem(7i32)).into_ptr(guard);
+                                let a = Owned::new(Elem(7i32)).into_shared(guard);
                                 guard.defer(move || a.into_owned());
                             }
                         }

--- a/src/guard.rs
+++ b/src/guard.rs
@@ -134,7 +134,7 @@ impl Guard {
     /// let guard = &epoch::pin();
     ///
     /// // Steal the object currently stored in `a` and swap it with another one.
-    /// let p = a.swap(Owned::new("bar").into_ptr(guard), SeqCst, guard);
+    /// let p = a.swap(Owned::new("bar").into_shared(guard), SeqCst, guard);
     ///
     /// if !p.is_null() {
     ///     // The object `p` is pointing to is now unreachable.

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -192,7 +192,7 @@ impl Local {
                 guard_count: Cell::new(0),
                 handle_count: Cell::new(1),
                 pin_count: Cell::new(Wrapping(0)),
-            }).into_ptr(&unprotected());
+            }).into_shared(&unprotected());
             global.locals.insert(local, &unprotected());
             Handle { local: local.as_raw() }
         }

--- a/src/sync/list.rs
+++ b/src/sync/list.rs
@@ -279,9 +279,9 @@ mod tests {
 
         let l: List<Entry, EntryContainer> = List::new();
 
-        let n1 = Owned::new(Entry::default()).into_ptr(&guard);
-        let n2 = Owned::new(Entry::default()).into_ptr(&guard);
-        let n3 = Owned::new(Entry::default()).into_ptr(&guard);
+        let n1 = Owned::new(Entry::default()).into_shared(&guard);
+        let n2 = Owned::new(Entry::default()).into_shared(&guard);
+        let n3 = Owned::new(Entry::default()).into_shared(&guard);
 
         unsafe {
             l.insert(n3, &guard);

--- a/src/sync/queue.rs
+++ b/src/sync/queue.rs
@@ -55,7 +55,7 @@ impl<T> Queue<T> {
         });
         unsafe {
             let guard = &unprotected();
-            let sentinel = sentinel.into_ptr(guard);
+            let sentinel = sentinel.into_shared(guard);
             q.head.store(sentinel, Relaxed);
             q.tail.store(sentinel, Relaxed);
             q
@@ -92,7 +92,7 @@ impl<T> Queue<T> {
             data: ManuallyDrop::new(t),
             next: Atomic::null(),
         });
-        let new = Owned::into_ptr(new, guard);
+        let new = Owned::into_shared(new, guard);
 
         loop {
             // We push onto the tail, so we'll start optimistically by looking there first.


### PR DESCRIPTION
We recently renamed `Ptr` into `Shared`, but I omitted `Owned::into_ptr()`..