### PR TITLE
Implement Guard::safepoint()

### DIFF
--- a/src/collector.rs
+++ b/src/collector.rs
@@ -325,22 +325,22 @@ mod tests {
         let collector = Collector::new();
         let handle = collector.handle();
 
-        unsafe {
-            let guard = &handle.pin();
+        let mut guard = handle.pin();
 
-            let mut v = Vec::with_capacity(COUNT);
-            for i in 0..COUNT {
-                v.push(Elem(i as i32));
-            }
+        let mut v = Vec::with_capacity(COUNT);
+        for i in 0..COUNT {
+            v.push(Elem(i as i32));
+        }
 
-            let a = Owned::new(v).into_shared(guard);
-            guard.defer(move || a.into_owned());
+        {
+            let a = Owned::new(v).into_shared(&guard);
+            unsafe { guard.defer(move || a.into_owned()); }
             guard.flush();
         }
 
         while DROPS.load(Ordering::Relaxed) < COUNT {
-            let guard = &handle.pin();
-            collector.global.collect(guard);
+            guard.safepoint();
+            collector.global.collect(&guard);
         }
         assert_eq!(DROPS.load(Ordering::Relaxed), COUNT);
     }

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -339,7 +339,7 @@ mod tests {
         }
 
         while DROPS.load(Ordering::Relaxed) < COUNT {
-            guard.safepoint();
+            guard.repin();
             collector.global.collect(&guard);
         }
         assert_eq!(DROPS.load(Ordering::Relaxed), COUNT);

--- a/src/guard.rs
+++ b/src/guard.rs
@@ -200,6 +200,9 @@ impl Guard {
     /// that is created before an invocation of `safepoint()` and then survives after the
     /// invocation.
     ///
+    /// The current thread will be repinned only if this is the only active guard. Otherwise,
+    /// `safepoint()` will be just a no-op.
+    ///
     /// # Examples
     ///
     /// ```

--- a/src/guard.rs
+++ b/src/guard.rs
@@ -240,6 +240,10 @@ impl Guard {
     ///
     /// If this method is called from an [`unprotected`] guard, then the passed function is called
     /// directly without unpinning the thread.
+    ///
+    /// # Examples
+    ///
+    /// ```
     /// use crossbeam_epoch::{self as epoch, Atomic};
     /// use std::sync::atomic::Ordering::SeqCst;
     /// use std::thread;


### PR DESCRIPTION
This is the implementation of `Guard::safepoint()` we discussed in https://github.com/crossbeam-rs/rfcs/issues/18.

I don't expect it to be merged before 0.1.0, but I'm personally in favor of doing so; I need it in implementing a wait-free queue.