### PR TITLE
Fix issues in sync/list and rename CasError.previous to current

### DIFF
--- a/src/internal.rs
+++ b/src/internal.rs
@@ -114,8 +114,9 @@ impl Global {
         for local in self.locals.iter(&guard) {
             match local {
                 Err(IterError::Stalled) => {
-                    // A concurrent thread stalled this iteration. Since it also tries to advance
-                    // the epoch, we leave the job to that thread.
+                    // A concurrent thread stalled this iteration. That thread might also try to
+                    // advance the epoch, in which case we leave the job to it. Otherwise, the
+                    // epoch will not be advanced.
                     return global_epoch;
                 }
                 Ok(local) => {

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -114,8 +114,8 @@ impl Global {
         for local in self.locals.iter(&guard) {
             match local {
                 Err(IterError::Stalled) => {
-                    // The iteration is stalled by another thread's iteration. Since that thread
-                    // also tries to advance the epoch, we leave the job to that thread.
+                    // A concurrent thread stalled this iteration. Since it also tries to advance
+                    // the epoch, we leave the job to that thread.
                     return global_epoch;
                 }
                 Ok(local) => {

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -31,13 +31,13 @@ use collector::Handle;
 use epoch::{AtomicEpoch, Epoch};
 use guard::{unprotected, Guard};
 use garbage::{Bag, Garbage};
-use sync::list::{List, Entry, IterError, Container};
+use sync::list::{List, Entry, IterError, IsElement};
 use sync::queue::Queue;
 
 /// The global data for a garbage collector.
 pub struct Global {
     /// The intrusive linked list of `Local`s.
-    locals: List<Local, LocalContainer>,
+    locals: List<Local>,
 
     /// The global queue of bags of deferred functions.
     queue: Queue<(Epoch, Bag)>,
@@ -336,21 +336,19 @@ impl Local {
     }
 }
 
-struct LocalContainer {}
-
-impl Container<Local> for LocalContainer {
-    fn container_of(entry: *const Entry) -> *const Local {
-        (entry as usize - offset_of!(Local, entry)) as *const _
+impl IsElement<Local> for Local {
+    fn entry_of(local: &Local) -> &Entry {
+        let entry_ptr = (local as *const Local as usize + offset_of!(Local, entry)) as *const Entry;
+        unsafe { &*entry_ptr }
     }
 
-    fn entry_of(local: *const Local) -> *const Entry {
-        (local as usize + offset_of!(Local, entry)) as *const _
+    unsafe fn element_of(entry: &Entry) -> &Local {
+        let local_ptr = (entry as *const Entry as usize - offset_of!(Local, entry)) as *const Local;
+        &*local_ptr
     }
 
-    fn finalize(entry: *const Entry) {
-        let local = Self::container_of(entry);
-        unsafe {
-            drop(Box::from_raw(local as *mut Local));
-        }
+    unsafe fn finalize(entry: &Entry) {
+        let local = Self::element_of(entry);
+        drop(Box::from_raw(local as *const Local as *mut Local));
     }
 }

--- a/src/sync/list.rs
+++ b/src/sync/list.rs
@@ -241,14 +241,9 @@ impl<'g, T: 'g, C: IsElement<T>> Iterator for Iter<'g, T, C> {
                 // This entry was removed. Try unlinking it from the list.
                 let succ = succ.with_tag(0);
 
-                if self.curr.tag() != 0 {
-                    // A concurrent thread deleted the predecessor node - we are stalled
-                    // and have to restart from `head`.
-                    self.pred = self.head;
-                    self.curr = self.head.load(Acquire, self.guard);
-
-                    return Some(Err(IterError::Stalled));
-                }
+                // The tag should never be zero, because removing a node after a logically deleted
+                // node leaves the list in an invalid state.
+                debug_assert!(self.curr.tag() == 0);
 
                 match self.pred.compare_and_set(
                     self.curr,

--- a/src/sync/list.rs
+++ b/src/sync/list.rs
@@ -181,7 +181,7 @@ impl<T, C: IsElement<T>> List<T, C> {
             match to.compare_and_set_weak(next, entry_ptr, Release, guard) {
                 Ok(_) => break,
                 // We lost the race or it failed spuriously. Update the successor and try again.
-                Err(err) => next = err.previous,
+                Err(err) => next = err.current,
             }
         }
     }
@@ -256,7 +256,7 @@ impl<'g, T: 'g, C: IsElement<T>> Iterator for Iter<'g, T, C> {
                     Err(err) => {
                         // We lost the race to delete the entry by a concurrent iterator. Set
                         // `self.curr` to the updated pointer, and report that we are stalled.
-                        self.curr = err.previous;
+                        self.curr = err.current;
                         return Some(Err(IterError::Stalled));
                     }
                 }

--- a/src/sync/list.rs
+++ b/src/sync/list.rs
@@ -19,15 +19,9 @@ pub struct Entry {
     next: Atomic<Entry>,
 }
 
-/// An evidence that the type `T` contains an entry.
-///
-/// Suppose we'll maintain an intrusive linked list of type `T`. Since `List` and `Entry` types do
-/// not provide any information on `T`, we need to specify how to interact with the containing
-/// objects of type `T`. A struct of this trait provides such information.
-///
-/// `container_of()` is given a pointer to an entry, and returns the pointer to its container. On
-/// the other hand, `entry_of()` is given a pointer to a container, and returns the pointer to its
-/// corresponding entry. `finalize()` is called when an element is actually removed from the list.
+/// Implementing this trait asserts that the type `T` can be used as an element in the intrusive
+/// linked list defined in this module. `T` has to contain (or otherwise be linked to) an instance
+/// of `Entry`.
 ///
 /// # Example
 ///
@@ -37,28 +31,31 @@ pub struct Entry {
 ///     data: usize,
 /// }
 ///
-/// struct AEntry {}
-///
-/// impl Container<A> for AEntry {
-///     fn container_of(entry: *const Entry) -> *const A {
-///         ((entry as usize) - offset_of!(A, entry)) as *const _
+/// impl IsElement<A> for A {
+///     fn entry_of(a: &A) -> &Entry {
+///         let entry_ptr = ((a as usize) + offset_of!(A, entry)) as *const Entry;
+///         unsafe { &*entry_ptr }
 ///     }
 ///
-///     fn entry_of(a: *const A) -> *const Entry {
-///         ((a as usize) + offset_of!(A, entry)) as *const _
+///     unsafe fn element_of(entry: &Entry) -> &T {
+///         let elem_ptr = ((entry as usize) - offset_of!(A, entry)) as *const T;
+///         &*elem_ptr
 ///     }
 ///
-///     fn finalize(entry: *const Entry) {
-///         // drop the box of the container
-///         unsafe { drop(Box::from_raw(Self::container_of(entry) as *mut A)) }
+///     unsafe fn finalize(entry: &Entry) {
+///         let elem = Self::element_of(entry);
+///         drop(Box::from_raw(elem as *const A as *mut A));
 ///     }
 /// }
 /// ```
 ///
-/// Note that there can be multiple structs that implement `Container<T>`. In most cases, each
-/// struct will represent a distinct entry in `T` so that the container can be inserted into
-/// multiple lists. For example, we can insert the following struct into two lists using `entry1`
-/// and `entry2` ans its entry:
+/// This trait is implemented on a type separate from `T` (although it can be just `T`), because
+/// one type might be placeable into multiple lists, in which case it would require multiple
+/// implementations of `IsElement`. In such cases, each struct implementing `IsElement<T>`
+/// represents a distinct `Entry` in `T`.
+///
+/// For example, we can insert the following struct into two lists using `entry1` for one
+/// and `entry2` for the other:
 ///
 /// ```ignore
 /// struct B {
@@ -67,24 +64,45 @@ pub struct Entry {
 ///     data: usize,
 /// }
 /// ```
-pub trait Container<T> {
-    fn container_of(*const Entry) -> *const T;
-    fn entry_of(*const T) -> *const Entry;
-    fn finalize(*const Entry);
+///
+pub trait IsElement<T> {
+    /// Returns a reference to this element's `Entry`.
+    fn entry_of(&T) -> &Entry;
+
+    /// Given a reference to an element's entry, returns that element.
+    ///
+    /// ```ignore
+    /// let elem = ListElement::new();
+    /// assert_eq!(elem.entry_of(),
+    ///            unsafe { ListElement::element_of(elem.entry_of()) } );
+    /// ```
+    ///
+    /// # Safety
+    /// The caller has to guarantee that the `Entry` it
+    /// is called with was retrieved from an instance of the element type (`T`).
+    unsafe fn element_of(&Entry) -> &T;
+
+    /// Deallocates the whole element given its `Entry`. This is called when the list
+    /// is ready to actually free the element.
+    ///
+    /// # Safety
+    /// The caller has to guarantee that the `Entry` it
+    /// is called with was retrieved from an instance of the element type (`T`).
+    unsafe fn finalize(&Entry);
 }
 
 /// A lock-free, intrusive linked list of type `T`.
 #[derive(Debug)]
-pub struct List<T, C: Container<T>> {
+pub struct List<T, C: IsElement<T> = T> {
     /// The head of the linked list.
     head: Atomic<Entry>,
 
-    /// The phantom data for using `T` and `E`.
+    /// The phantom data for using `T` and `C`.
     _marker: PhantomData<(T, C)>,
 }
 
-/// An auxiliary data for iterating over a linked list.
-pub struct Iter<'g, T: 'g, C: Container<T>> {
+/// An iterator used for retrieving values from the list.
+pub struct Iter<'g, T: 'g, C: IsElement<T>> {
     /// The guard that protects the iteration.
     guard: &'g Guard,
 
@@ -94,7 +112,8 @@ pub struct Iter<'g, T: 'g, C: Container<T>> {
     /// The current entry.
     curr: Shared<'g, Entry>,
 
-    /// The phantom data for container.
+    /// Logically, we store a borrow of an instance of `T` and
+    /// use the type information from `C`.
     _marker: PhantomData<(&'g T, C)>,
 }
 
@@ -118,15 +137,15 @@ impl Entry {
     ///
     /// # Safety
     ///
-    /// The entry should be a member of a linked list, and it should not have been deleted. It
-    /// should be safe to call `C::finalize` on the entry after the `guard` is dropped, where `C` is
-    /// the associated helper for the linked list.
+    /// The entry should be a member of a linked list, and it should not have been deleted.
+    /// It should be safe to call `C::finalize` on the entry after the `guard` is dropped, where `C`
+    /// is the associated helper for the linked list.
     pub unsafe fn delete(&self, guard: &Guard) {
         self.next.fetch_or(1, Release, guard);
     }
 }
 
-impl<T, C: Container<T>> List<T, C> {
+impl<T, C: IsElement<T>> List<T, C> {
     /// Returns a new, empty linked list.
     pub fn new() -> Self {
         Self {
@@ -141,22 +160,28 @@ impl<T, C: Container<T>> List<T, C> {
     ///
     /// You should guarantee that:
     ///
-    /// - `C::entry_of()` properly accesses an `Entry` in the container;
-    /// - `C::container_of()` properly accesses the object containing the entry;
-    /// - `container` is immovable, e.g. inside a `Box`;
-    /// - An entry is not inserted twice; and
-    /// - The inserted object will be removed before the list is dropped.
+    /// - `container` is not null
+    /// - `container` is immovable, e.g. inside a `Box`
+    /// - the same `Entry` is not inserted more than once
+    /// - the inserted object will be removed before the list is dropped
     pub unsafe fn insert<'g>(&'g self, container: Shared<'g, T>, guard: &'g Guard) {
+        // Insert right after head, i.e. at the beginning of the list.
         let to = &self.head;
-        let entry = &*C::entry_of(container.as_raw());
+        // Get the intrusively stored Entry of the new element to insert.
+        let entry: &Entry = C::entry_of(container.deref());
+        // Make a Shared ptr to that Entry.
         let entry_ptr = Shared::from(entry as *const _);
+        // Read the current successor of where we want to insert.
         let mut next = to.load(Relaxed, guard);
 
         loop {
+            // Set the Entry of the to-be-inserted element to point to the previous successor of
+            // `to`.
             entry.next.store(next, Relaxed);
             match to.compare_and_set_weak(next, entry_ptr, Release, guard) {
                 Ok(_) => break,
-                Err(err) => next = err.new,
+                // We lost the race or it failed spuriously. Update the successor and try again.
+                Err(err) => next = err.previous,
             }
         }
     }
@@ -185,23 +210,24 @@ impl<T, C: Container<T>> List<T, C> {
     }
 }
 
-impl<T, C: Container<T>> Drop for List<T, C> {
+impl<T, C: IsElement<T>> Drop for List<T, C> {
     fn drop(&mut self) {
         unsafe {
             let guard = &unprotected();
             let mut curr = self.head.load(Relaxed, guard);
             while let Some(c) = curr.as_ref() {
                 let succ = c.next.load(Relaxed, guard);
+                // Verify that all elements have been removed from the list.
                 assert_eq!(succ.tag(), 1);
 
-                C::finalize(curr.as_raw());
+                C::finalize(curr.deref());
                 curr = succ;
             }
         }
     }
 }
 
-impl<'g, T: 'g, C: Container<T>> Iterator for Iter<'g, T, C> {
+impl<'g, T: 'g, C: IsElement<T>> Iterator for Iter<'g, T, C> {
     type Item = Result<&'g T, IterError>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -213,7 +239,7 @@ impl<'g, T: 'g, C: Container<T>> Iterator for Iter<'g, T, C> {
                 let succ = succ.with_tag(0);
 
                 match self.pred.compare_and_set_weak(
-                    self.curr,
+                    self.curr.with_tag(0),
                     succ,
                     Acquire,
                     self.guard,
@@ -223,14 +249,14 @@ impl<'g, T: 'g, C: Container<T>> Iterator for Iter<'g, T, C> {
                             // Deferred drop of `T` is scheduled here.
                             // This is okay because `.delete()` can be called only if `T: 'static`.
                             let p = self.curr;
-                            self.guard.defer(move || C::finalize(p.as_raw()));
+                            self.guard.defer(move || C::finalize(p.deref()));
                         }
                         self.curr = succ;
                     }
                     Err(err) => {
                         // We lost the race to delete the entry by a concurrent iterator. Set
                         // `self.curr` to the updated pointer, and report that we are stalled.
-                        self.curr = err.new;
+                        self.curr = err.previous;
                         return Some(Err(IterError::Stalled));
                     }
                 }
@@ -242,7 +268,7 @@ impl<'g, T: 'g, C: Container<T>> Iterator for Iter<'g, T, C> {
             self.pred = &c.next;
             self.curr = succ;
 
-            return Some(Ok(unsafe { &*C::container_of(c as *const _) }));
+            return Some(Ok(unsafe { C::element_of(c) }));
         }
 
         // We reached the end of the list.
@@ -253,61 +279,182 @@ impl<'g, T: 'g, C: Container<T>> Iterator for Iter<'g, T, C> {
 #[cfg(test)]
 mod tests {
     use {Collector, Owned};
+    use crossbeam_utils::scoped;
+    use std::sync::Barrier;
     use super::*;
 
+    impl IsElement<Entry> for Entry {
+        fn entry_of(entry: &Entry) -> &Entry {
+            entry
+        }
+
+        unsafe fn element_of(entry: &Entry) -> &Entry {
+            entry
+        }
+
+        unsafe fn finalize(entry: &Entry) {
+            drop(Box::from_raw(entry as *const Entry as *mut Entry));
+        }
+    }
+
+    /// Checks whether the list retains inserted elements
+    /// and returns them in the correct order.
     #[test]
-    fn insert_iter_delete_iter() {
+    fn insert() {
         let collector = Collector::new();
         let handle = collector.handle();
         let guard = handle.pin();
 
-        struct EntryContainer {}
+        let l: List<Entry> = List::new();
 
-        impl Container<Entry> for EntryContainer {
-            fn container_of(entry: *const Entry) -> *const Entry {
-                entry
-            }
-
-            fn entry_of(entry: *const Entry) -> *const Entry {
-                entry
-            }
-
-            fn finalize(entry: *const Entry) {
-                unsafe { drop(Box::from_raw(entry as *mut Entry)) }
-            }
-        }
-
-        let l: List<Entry, EntryContainer> = List::new();
-
-        let n1 = Owned::new(Entry::default()).into_shared(&guard);
-        let n2 = Owned::new(Entry::default()).into_shared(&guard);
-        let n3 = Owned::new(Entry::default()).into_shared(&guard);
+        let e1 = Owned::new(Entry::default()).into_shared(&guard);
+        let e2 = Owned::new(Entry::default()).into_shared(&guard);
+        let e3 = Owned::new(Entry::default()).into_shared(&guard);
 
         unsafe {
-            l.insert(n3, &guard);
-            l.insert(n2, &guard);
-            l.insert(n1, &guard);
+            l.insert(e1, &guard);
+            l.insert(e2, &guard);
+            l.insert(e3, &guard);
         }
 
         let mut iter = l.iter(&guard);
-        assert!(iter.next().is_some());
-        assert!(iter.next().is_some());
-        assert!(iter.next().is_some());
+        let maybe_e3 = iter.next();
+        assert!(maybe_e3.is_some());
+        assert!(maybe_e3.unwrap().unwrap() as *const Entry == e3.as_raw());
+        let maybe_e2 = iter.next();
+        assert!(maybe_e2.is_some());
+        assert!(maybe_e2.unwrap().unwrap() as *const Entry == e2.as_raw());
+        let maybe_e1 = iter.next();
+        assert!(maybe_e1.is_some());
+        assert!(maybe_e1.unwrap().unwrap() as *const Entry == e1.as_raw());
         assert!(iter.next().is_none());
 
         unsafe {
-            n2.as_ref().unwrap().delete(&guard);
+            e1.as_ref().unwrap().delete(&guard);
+            e2.as_ref().unwrap().delete(&guard);
+            e3.as_ref().unwrap().delete(&guard);
+        }
+    }
+
+    /// Checks whether elements can be removed from the list and whether
+    /// the correct elements are removed.
+    #[test]
+    fn delete() {
+        let collector = Collector::new();
+        let handle = collector.handle();
+        let guard = handle.pin();
+
+        let l: List<Entry> = List::new();
+
+        let e1 = Owned::new(Entry::default()).into_shared(&guard);
+        let e2 = Owned::new(Entry::default()).into_shared(&guard);
+        let e3 = Owned::new(Entry::default()).into_shared(&guard);
+        unsafe {
+            l.insert(e1, &guard);
+            l.insert(e2, &guard);
+            l.insert(e3, &guard);
+            e2.as_ref().unwrap().delete(&guard);
         }
 
         let mut iter = l.iter(&guard);
-        assert!(iter.next().is_some());
-        assert!(iter.next().is_some());
+        let maybe_e3 = iter.next();
+        assert!(maybe_e3.is_some());
+        assert!(maybe_e3.unwrap().unwrap() as *const Entry == e3.as_raw());
+        let maybe_e1 = iter.next();
+        assert!(maybe_e1.is_some());
+        assert!(maybe_e1.unwrap().unwrap() as *const Entry == e1.as_raw());
         assert!(iter.next().is_none());
 
         unsafe {
-            n1.as_ref().unwrap().delete(&guard);
-            n3.as_ref().unwrap().delete(&guard);
+            e1.as_ref().unwrap().delete(&guard);
+            e3.as_ref().unwrap().delete(&guard);
         }
+
+        let mut iter = l.iter(&guard);
+        assert!(iter.next().is_none());
+    }
+
+    const THREADS: usize = 8;
+    const ITERS: usize = 512;
+
+    /// Contends the list on insert and delete operations to make sure they can run concurrently.
+    #[test]
+    fn insert_delete_multi() {
+        let collector = Collector::new();
+
+        let l: List<Entry> = List::new();
+        let b = Barrier::new(THREADS);
+
+        scoped::scope(|s| for _ in 0..THREADS {
+            s.spawn(|| {
+                b.wait();
+
+                let handle = collector.handle();
+                let guard: Guard = handle.pin();
+                let mut v = Vec::with_capacity(ITERS);
+
+                for _ in 0..ITERS {
+                    let e = Owned::new(Entry::default()).into_shared(&guard);
+                    v.push(e);
+                    unsafe {
+                        l.insert(e, &guard);
+                    }
+                }
+
+                for e in v {
+                    unsafe {
+                        e.as_ref().unwrap().delete(&guard);
+                    }
+                }
+            });
+        });
+
+        let handle = collector.handle();
+        let guard = handle.pin();
+
+        let mut iter = l.iter(&guard);
+        assert!(iter.next().is_none());
+    }
+
+    /// Contends the list on iteration to make sure that it can be iterated over concurrently.
+    #[test]
+    fn iter_multi() {
+        let collector = Collector::new();
+
+        let l: List<Entry> = List::new();
+        let b = Barrier::new(THREADS);
+
+        scoped::scope(|s| for _ in 0..THREADS {
+            s.spawn(|| {
+                b.wait();
+
+                let handle = collector.handle();
+                let guard: Guard = handle.pin();
+                let mut v = Vec::with_capacity(ITERS);
+
+                for _ in 0..ITERS {
+                    let e = Owned::new(Entry::default()).into_shared(&guard);
+                    v.push(e);
+                    unsafe {
+                        l.insert(e, &guard);
+                    }
+                }
+
+                let mut iter = l.iter(&guard);
+                for _ in 0..ITERS {
+                    assert!(iter.next().is_some());
+                }
+
+                for e in v {
+                    unsafe {
+                        e.as_ref().unwrap().delete(&guard);
+                    }
+                }
+            });
+        });
+
+        let handle = collector.handle();
+        let guard = handle.pin();
 
         let mut iter = l.iter(&guard);
         assert!(iter.next().is_none());

--- a/src/sync/list.rs
+++ b/src/sync/list.rs
@@ -251,7 +251,7 @@ impl<'g, T: 'g, C: IsElement<T>> Iterator for Iter<'g, T, C> {
                 }
 
                 match self.pred.compare_and_set(
-                    self.curr.with_tag(0),
+                    self.curr,
                     succ,
                     Acquire,
                     self.guard,


### PR DESCRIPTION
This PR fixes two bugs in `sync/list.rs`, one of them being due to the wrong field of a tuple returned from `compare_and_set` being used [here](https://github.com/crossbeam-rs/crossbeam-epoch/blob/a25ef9dc2dc0239d062d921da7e040c2477b1795/src/sync/list.rs#L159) (unnamed fields are evil!) and the other [here](https://github.com/crossbeam-rs/crossbeam-epoch/blob/a25ef9dc2dc0239d062d921da7e040c2477b1795/src/sync/list.rs#L216). A few tests to catch these are added. Additionally, it renames `Container` to `IsElement` and makes it use references instead of pointers.

Then, I also renamed `CasError.previous` to `current`, the reasoning being that at the time of CAS failure this value is still in the pointer, so it's "currently" there.