### PR TITLE
Add the ability to temporarily unpin a Guard

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,4 @@ arrayvec = { version = "0.4", default-features = false }
 crossbeam-utils = { version = "0.1", default-features = false }
 lazy_static = { version = "0.2", optional = true }
 memoffset = { version = "0.1", default-features = false }
+scopeguard = { version = "0.3", default-features = false }

--- a/src/guard.rs
+++ b/src/guard.rs
@@ -198,7 +198,7 @@ impl Drop for Guard {
     #[inline]
     fn drop(&mut self) {
         if let Some(local) = unsafe { self.local.as_ref() } {
-            Local::unpin(local);
+            local.unpin();
         }
     }
 }

--- a/src/guard.rs
+++ b/src/guard.rs
@@ -197,8 +197,9 @@ impl Guard {
     /// Temporarily unpins the thread, executes the given function and then re-pins the thread.
     ///
     /// This method is useful when you need to perform a long-running operation (e.g. sleeping)
-    /// and don't need to maintain any guard-based reference across the call. The thread will only
-    /// be unpinned if this is the only active guard for the current thread.
+    /// and don't need to maintain any guard-based reference across the call (the latter is enforced
+    /// by `&mut self`). The thread will only be unpinned if this is the only active guard for the
+    /// current thread.
     ///
     /// If this method is called from an [`unprotected`] guard, then the passed function is called
     /// directly without unpinning the thread.
@@ -217,7 +218,7 @@ impl Guard {
     ///     let p = a.load(SeqCst, &guard);
     ///     assert_eq!(unsafe { p.as_ref() }, Some(&777));
     /// }
-    /// guard.unpin_for(|| thread::sleep(Duration::from_millis(50)));
+    /// guard.repin_after(|| thread::sleep(Duration::from_millis(50)));
     /// {
     ///     let p = a.load(SeqCst, &guard);
     ///     assert_eq!(unsafe { p.as_ref() }, Some(&777));
@@ -225,7 +226,7 @@ impl Guard {
     /// ```
     ///
     /// [`unprotected`]: fn.unprotected.html
-    pub fn unpin_for<F, R>(&mut self, f: F) -> R
+    pub fn repin_after<F, R>(&mut self, f: F) -> R
     where
         F: FnOnce() -> R,
     {

--- a/src/guard.rs
+++ b/src/guard.rs
@@ -1,4 +1,5 @@
 use core::ptr;
+use core::mem;
 
 use garbage::Garbage;
 use internal::Local;
@@ -191,6 +192,63 @@ impl Guard {
         if let Some(local) = unsafe { self.local.as_ref() } {
             local.flush(self);
         }
+    }
+
+    /// Temporarily unpins the thread, executes the given function and then re-pins the thread.
+    ///
+    /// This method is useful when you need to perform a long-running operation (e.g. sleeping)
+    /// and don't need to maintain any guard-based reference across the call. The thread will only
+    /// be unpinned if this is the only active guard for the current thread.
+    ///
+    /// If this method is called from an [`unprotected`] guard, then the passed function is called
+    /// directly without unpinning the thread.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use crossbeam_epoch::{self as epoch, Atomic};
+    /// use std::sync::atomic::Ordering::SeqCst;
+    /// use std::thread;
+    /// use std::time::Duration;
+    ///
+    /// let a = Atomic::new(777);
+    /// let mut guard = epoch::pin();
+    /// {
+    ///     let p = a.load(SeqCst, &guard);
+    ///     assert_eq!(unsafe { p.as_ref() }, Some(&777));
+    /// }
+    /// guard.unpin_for(|| thread::sleep(Duration::from_millis(50)));
+    /// {
+    ///     let p = a.load(SeqCst, &guard);
+    ///     assert_eq!(unsafe { p.as_ref() }, Some(&777));
+    /// }
+    /// ```
+    ///
+    /// [`unprotected`]: fn.unprotected.html
+    pub fn unpin_for<F, R>(&mut self, f: F) -> R
+    where
+        F: FnOnce() -> R,
+    {
+        if let Some(local) = unsafe { self.local.as_ref() } {
+            // We need to acquire a handle here to ensure the Local doesn't
+            // disappear from under us.
+            local.acquire_handle();
+            local.unpin();
+        }
+
+        // Ensure the Guard is re-pinned even if the function panics
+        struct PanicGuard(*const Local);
+        impl Drop for PanicGuard {
+            fn drop(&mut self) {
+                if let Some(local) = unsafe { self.0.as_ref() } {
+                    mem::forget(local.pin());
+                    local.release_handle();
+                }
+            }
+        }
+        let _guard = PanicGuard(self.local);
+
+        f()
     }
 }
 

--- a/src/guard.rs
+++ b/src/guard.rs
@@ -237,16 +237,12 @@ impl Guard {
         }
 
         // Ensure the Guard is re-pinned even if the function panics
-        struct PanicGuard(*const Local);
-        impl Drop for PanicGuard {
-            fn drop(&mut self) {
-                if let Some(local) = unsafe { self.0.as_ref() } {
-                    mem::forget(local.pin());
-                    local.release_handle();
-                }
+        defer! {
+            if let Some(local) = unsafe { self.local.as_ref() } {
+                mem::forget(local.pin());
+                local.release_handle();
             }
         }
-        let _guard = PanicGuard(self.local);
 
         f()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,8 @@ extern crate crossbeam_utils;
 extern crate lazy_static;
 #[macro_use]
 extern crate memoffset;
+#[macro_use]
+extern crate scopeguard;
 
 mod atomic;
 mod collector;


### PR DESCRIPTION
This is similar to #43, but allows a function to be executed with the guard unpinned. I need this functionality for my use case where a thread will stay pinned most of the time, except for some potentially long-running system calls.