### PR TITLE
Add no_std support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,14 @@ rust:
 script:
   - cargo build
   - cargo build --release
+  - cargo build --no-default-features
+  - cargo build --release --no-default-features
   - cargo test
   - cargo test --release
   - |
     if [ $TRAVIS_RUST_VERSION == nightly ]; then
+      cargo build --features nightly --no-default-features
+      cargo build --features nightly --release --no-default-features
       cargo test --features nightly
       cargo test --features nightly --release
     fi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,14 +12,13 @@ keywords = ["lock-free", "rcu", "atomic", "garbage"]
 categories = ["concurrency", "memory-management"]
 
 [features]
-nightly = []
+default = ["std"]
+std = ["lazy_static"]
+nightly = ["arrayvec/use_union"]
 strict_gc = []
 
 [dependencies]
-arrayvec = "0.4"
-crossbeam-utils = "0.1"
-lazy_static = "0.2"
-memoffset = "0.1.0"
-
-[dev-dependencies]
-rand = "0.3"
+arrayvec = { version = "0.4", default-features = false }
+crossbeam-utils = { version = "0.1", default-features = false }
+lazy_static = { version = "0.2", optional = true }
+memoffset = { version = "0.1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ keywords = ["lock-free", "rcu", "atomic", "garbage"]
 categories = ["concurrency", "memory-management"]
 
 [features]
-default = ["std"]
-std = ["lazy_static"]
+default = ["use_std"]
+use_std = ["lazy_static"]
 nightly = ["arrayvec/use_union"]
 strict_gc = []
 

--- a/src/atomic.rs
+++ b/src/atomic.rs
@@ -1,12 +1,13 @@
-use std::borrow::{Borrow, BorrowMut};
-use std::cmp;
-use std::fmt;
-use std::marker::PhantomData;
-use std::mem;
-use std::ptr;
-use std::ops::{Deref, DerefMut};
-use std::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT};
-use std::sync::atomic::Ordering;
+use core::borrow::{Borrow, BorrowMut};
+use core::cmp;
+use core::fmt;
+use core::marker::PhantomData;
+use core::mem;
+use core::ptr;
+use core::ops::{Deref, DerefMut};
+use core::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT};
+use core::sync::atomic::Ordering;
+use alloc::boxed::Box;
 
 use guard::Guard;
 

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -13,10 +13,7 @@
 /// handle.pin().flush();
 /// ```
 
-#[cfg(feature = "nightly")]
 use alloc::arc::Arc;
-#[cfg(not(feature = "nightly"))]
-use alloc::sync::Arc;
 
 use internal::{Global, Local};
 use guard::Guard;

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -13,7 +13,10 @@
 /// handle.pin().flush();
 /// ```
 
-use std::sync::Arc;
+#[cfg(feature = "nightly")]
+use alloc::arc::Arc;
+#[cfg(not(feature = "nightly"))]
+use alloc::sync::Arc;
 
 use internal::{Global, Local};
 use guard::Guard;

--- a/src/deferred.rs
+++ b/src/deferred.rs
@@ -1,5 +1,6 @@
-use std::mem;
-use std::ptr;
+use core::mem;
+use core::ptr;
+use alloc::boxed::Box;
 
 /// Number of words a piece of `Data` can hold.
 ///

--- a/src/epoch.rs
+++ b/src/epoch.rs
@@ -7,8 +7,8 @@
 //! If an object became garbage in some epoch, then we can be sure that after two advancements no
 //! participant will hold a reference to it. That is the crux of safe memory reclamation.
 
-use std::cmp;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use core::cmp;
+use core::sync::atomic::{AtomicUsize, Ordering};
 
 /// An epoch that can be marked as pinned or unpinned.
 ///

--- a/src/garbage.rs
+++ b/src/garbage.rs
@@ -24,7 +24,7 @@
 //! concurrent data structure may have its own queue that gets fully destroyed as soon as the data
 //! structure gets dropped.
 
-use std::fmt;
+use core::fmt;
 use arrayvec::ArrayVec;
 use deferred::Deferred;
 

--- a/src/guard.rs
+++ b/src/guard.rs
@@ -1,4 +1,4 @@
-use std::ptr;
+use core::ptr;
 
 use garbage::Garbage;
 use internal::Local;

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -23,10 +23,7 @@ use core::ptr;
 use core::sync::atomic;
 use core::sync::atomic::Ordering::{Acquire, Relaxed, Release, SeqCst};
 use alloc::boxed::Box;
-#[cfg(feature = "nightly")]
 use alloc::arc::Arc;
-#[cfg(not(feature = "nightly"))]
-use alloc::sync::Arc;
 
 use crossbeam_utils::cache_padded::CachePadded;
 

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -16,13 +16,17 @@
 //! When a participant is pinned, a `Guard` is returned as a witness that the participant is pinned.
 //! Guards are necessary for performing atomic operations, and for freeing/dropping locations.
 
-use std::cell::{Cell, UnsafeCell};
-use std::mem::{self, ManuallyDrop};
-use std::num::Wrapping;
-use std::ptr;
-use std::sync::Arc;
-use std::sync::atomic;
-use std::sync::atomic::Ordering::{Acquire, Relaxed, Release, SeqCst};
+use core::cell::{Cell, UnsafeCell};
+use core::mem::{self, ManuallyDrop};
+use core::num::Wrapping;
+use core::ptr;
+use core::sync::atomic;
+use core::sync::atomic::Ordering::{Acquire, Relaxed, Release, SeqCst};
+use alloc::boxed::Box;
+#[cfg(feature = "nightly")]
+use alloc::arc::Arc;
+#[cfg(not(feature = "nightly"))]
+use alloc::sync::Arc;
 
 use crossbeam_utils::cache_padded::CachePadded;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,12 @@ extern crate core;
 #[cfg(feature = "nightly")]
 extern crate alloc;
 #[cfg(not(feature = "nightly"))]
-extern crate std as alloc;
+mod alloc {
+    // Tweak the module layout to match the one in liballoc
+    extern crate std;
+    pub use self::std::boxed;
+    pub use self::std::sync as arc;
+}
 
 extern crate arrayvec;
 extern crate crossbeam_utils;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@
 #![cfg_attr(feature = "nightly", feature(alloc))]
 #![cfg_attr(not(test), no_std)]
 
-#[cfg(all(not(test), feature = "std"))]
+#[cfg(all(not(test), feature = "use_std"))]
 #[macro_use]
 extern crate std;
 #[cfg(test)]
@@ -77,7 +77,7 @@ mod alloc {
 
 extern crate arrayvec;
 extern crate crossbeam_utils;
-#[cfg(feature = "std")]
+#[cfg(feature = "use_std")]
 #[macro_use]
 extern crate lazy_static;
 #[macro_use]
@@ -85,7 +85,7 @@ extern crate memoffset;
 
 mod atomic;
 mod collector;
-#[cfg(feature = "std")]
+#[cfg(feature = "use_std")]
 mod default;
 mod deferred;
 mod epoch;
@@ -96,6 +96,6 @@ mod sync;
 
 pub use self::atomic::{Atomic, CompareAndSetError, CompareAndSetOrdering, Owned, Shared};
 pub use self::guard::{unprotected, Guard};
-#[cfg(feature = "std")]
+#[cfg(feature = "use_std")]
 pub use self::default::{default_handle, is_pinned, pin};
 pub use self::collector::{Collector, Handle};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,9 +55,24 @@
 //! [`defer`]: fn.defer.html
 
 #![cfg_attr(feature = "nightly", feature(const_fn))]
+#![cfg_attr(feature = "nightly", feature(alloc))]
+#![cfg_attr(not(test), no_std)]
+
+#[cfg(all(not(test), feature = "std"))]
+#[macro_use]
+extern crate std;
+#[cfg(test)]
+extern crate core;
+
+// Use liballoc on nightly to avoid a dependency on libstd
+#[cfg(feature = "nightly")]
+extern crate alloc;
+#[cfg(not(feature = "nightly"))]
+extern crate std as alloc;
 
 extern crate arrayvec;
 extern crate crossbeam_utils;
+#[cfg(feature = "std")]
 #[macro_use]
 extern crate lazy_static;
 #[macro_use]
@@ -65,6 +80,7 @@ extern crate memoffset;
 
 mod atomic;
 mod collector;
+#[cfg(feature = "std")]
 mod default;
 mod deferred;
 mod epoch;
@@ -75,5 +91,6 @@ mod sync;
 
 pub use self::atomic::{Atomic, CompareAndSetError, CompareAndSetOrdering, Owned, Shared};
 pub use self::guard::{unprotected, Guard};
+#[cfg(feature = "std")]
 pub use self::default::{default_handle, is_pinned, pin};
 pub use self::collector::{Collector, Handle};

--- a/src/sync/list.rs
+++ b/src/sync/list.rs
@@ -3,8 +3,8 @@
 //! Ideas from Michael.  High Performance Dynamic Lock-Free Hash Tables and List-Based Sets.  SPAA
 //! 2002.  http://dl.acm.org/citation.cfm?id=564870.564881
 
-use std::marker::PhantomData;
-use std::sync::atomic::Ordering::{Acquire, Relaxed, Release};
+use core::marker::PhantomData;
+use core::sync::atomic::Ordering::{Acquire, Relaxed, Release};
 
 use {Atomic, Shared, Guard, unprotected};
 

--- a/src/sync/queue.rs
+++ b/src/sync/queue.rs
@@ -5,9 +5,9 @@
 //! Michael and Scott.  Simple, Fast, and Practical Non-Blocking and Blocking Concurrent Queue
 //! Algorithms.  PODC 1996.  http://dl.acm.org/citation.cfm?id=248106
 
-use std::mem::{self, ManuallyDrop};
-use std::ptr;
-use std::sync::atomic::Ordering::{Acquire, Relaxed, Release};
+use core::mem::{self, ManuallyDrop};
+use core::ptr;
+use core::sync::atomic::Ordering::{Acquire, Relaxed, Release};
 
 use crossbeam_utils::cache_padded::CachePadded;
 


### PR DESCRIPTION
This PR enables no_std support for crossbeam-epoch. It depends on crossbeam-rs/crossbeam-utils#3.

The only API-level change is that a default collector is only provided if the "std" feature is enabled (it is enabled by default).

Note that no_std is only properly supported if the "std" feature is disabled **and** the "nightly" feature is enabled. This is because this crate uses `Box` and `Arc` which depend on liballoc.