### PR TITLE
Update crossbeam-util version to 0.2 for no_std support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["concurrency", "memory-management"]
 
 [features]
 default = ["use_std"]
-use_std = ["lazy_static"]
+use_std = ["lazy_static", "crossbeam-utils/use_std"]
 nightly = ["arrayvec/use_union"]
 strict_gc = []
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ strict_gc = []
 
 [dependencies]
 arrayvec = { version = "0.4", default-features = false }
-crossbeam-utils = { version = "0.1", default-features = false }
+crossbeam-utils = { version = "0.2", default-features = false }
 lazy_static = { version = "0.2", optional = true }
 memoffset = { version = "0.1", default-features = false }
 scopeguard = { version = "0.3", default-features = false }


### PR DESCRIPTION
Missed this in #46.