### PR TITLE
Fix an ordering bug in Global::push_bag()

### DIFF
--- a/src/internal.rs
+++ b/src/internal.rs
@@ -63,11 +63,11 @@ impl Global {
 
     /// Pushes the bag into the global queue and replaces the bag with a new empty bag.
     pub fn push_bag(&self, bag: &mut Bag, guard: &Guard) {
-        let epoch = self.epoch.load(Ordering::Relaxed);
         let bag = mem::replace(bag, Bag::new());
 
         atomic::fence(Ordering::SeqCst);
 
+        let epoch = self.epoch.load(Ordering::Relaxed);
         self.queue.push((epoch, bag), guard);
     }
 


### PR DESCRIPTION
In an RFC (https://github.com/crossbeam-rs/rfcs/blob/master/text/2017-07-23-relaxed-memory.md), we explained why Crossbeam is correct in relaxed memory.  However, the pseudocode in the RFC and the implementation differs: in `unlink()` in RFC, a `SeqCst` fence is executed and then the global epoch is read.  On the other hand, in `push_bag()` in the implementation, the global epoch is read and then a `SeqCst` fence is executed.


Unfortunately, the current implementation is incorrect.  For example, consider the following scenario:

- Thread A is pinned at epoch 10, and deferring the deallocation of an object O.
- In `Global::push_bag()`, A can read the global epoch 10, and then sleeps for a long time.
- In the mean time, the global epoch advanced to 11.
- Thread B is pinned with local epoch 11, and got a reference to O.
- Thread A woke up and executes the `SeqCst` fence, and then it is unpinned.
- The global epoch advances to 12.
- Thread C actually deallocates O, while B has a reference to it...

This PR fixes it by reordering `fence(SeqCst)` and a load from the global epoch in `Global::push_bag()`.


Arguably, the performance remains almost the same after this PR.  This is an one-time measurement of `cargo bench` (control = master, variable = this PR):

```
 name                       control ns/iter  variable ns/iter  diff ns/iter  diff %  speedup
 multi_alloc_defer_free     3,581,149        3,608,989               27,840   0.78%   x 0.99
 multi_defer                1,640,773        1,630,437              -10,336  -0.63%   x 1.01
 multi_flush                7,538,490        7,519,137              -19,353  -0.26%   x 1.00
 multi_pin                  4,725,144        4,674,670              -50,474  -1.07%   x 1.01
 single_alloc_defer_free    49               53                           4   8.16%   x 0.92
 single_default_handle_pin  9                9                            0   0.00%   x 1.00
 single_defer               27               30                           3  11.11%   x 0.90
 single_flush               214              206                         -8  -3.74%   x 1.04
 single_pin                 9                9                            0   0.00%   x 1.00
```


This PR is blocked by #52: here I just commented out `impl<T> Into<Box<T>> for Owned<T>`, but it should be properly dealt with in another PR.