### PR TITLE
Support Rust 1.13.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rust:
   - stable
   - beta
   - nightly
+  - 1.13.0
 
 addons:
   apt:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ use_std = ["lazy_static", "crossbeam-utils/use_std"]
 
 [dependencies]
 arrayvec = { version = "0.4", default-features = false }
-nodrop = { version = "0.1.12", default-features = false }
 cfg-if = "0.1"
 crossbeam-utils = { version = "0.2", default-features = false }
 lazy_static = { version = "0.2", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,11 @@ use_std = ["lazy_static", "crossbeam-utils/use_std"]
 
 [dependencies]
 arrayvec = { version = "0.4", default-features = false }
+nodrop = { version = "0.1.12", default-features = false }
 cfg-if = "0.1"
 crossbeam-utils = { version = "0.2", default-features = false }
 lazy_static = { version = "0.2", optional = true }
-memoffset = { version = "0.1", default-features = false }
+memoffset = { version = "0.2" }
 scopeguard = { version = "0.3", default-features = false }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ use_std = ["lazy_static", "crossbeam-utils/use_std"]
 
 [dependencies]
 arrayvec = { version = "0.4", default-features = false }
+nodrop = { version = "0.1.12", default-features = false }
 cfg-if = "0.1"
 crossbeam-utils = { version = "0.2", default-features = false }
 lazy_static = { version = "0.2", optional = true }

--- a/src/atomic.rs
+++ b/src/atomic.rs
@@ -15,11 +15,10 @@ use guard::Guard;
 /// appropriate ordering for the failure case.
 #[inline]
 fn strongest_failure_ordering(ord: Ordering) -> Ordering {
-    use self::Ordering::*;
     match ord {
-        Relaxed | Release => Relaxed,
-        Acquire | AcqRel => Acquire,
-        _ => SeqCst,
+        Ordering::Relaxed | Ordering::Release => Ordering::Relaxed,
+        Ordering::Acquire | Ordering::AcqRel => Ordering::Acquire,
+        _ => Ordering::SeqCst,
     }
 }
 
@@ -134,8 +133,8 @@ unsafe impl<T: Send + Sync> Sync for Atomic<T> {}
 
 impl<T> Atomic<T> {
     /// Returns a new atomic pointer pointing to the tagged pointer `data`.
-    fn from_data(data: usize) -> Self {
-        Self {
+    fn from_data(data: usize) -> Atomic<T> {
+        Atomic {
             data: AtomicUsize::new(data),
             _marker: PhantomData,
         }
@@ -152,7 +151,7 @@ impl<T> Atomic<T> {
     /// ```
     #[cfg(not(feature = "nightly"))]
     pub fn null() -> Atomic<T> {
-        Self {
+        Atomic {
             data: ATOMIC_USIZE_INIT,
             _marker: PhantomData,
         }

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -34,7 +34,7 @@ impl Collector {
 
     /// Creates a new handle for the collector.
     pub fn handle(&self) -> Handle {
-        Local::register(self.global.clone())
+        Handle { local: Local::register(&self.global) }
     }
 }
 
@@ -47,7 +47,7 @@ impl Clone for Collector {
 
 /// A handle to a garbage collector.
 pub struct Handle {
-    pub(crate) local: *const Local,
+    local: *const Local,
 }
 
 impl Handle {
@@ -128,9 +128,9 @@ mod tests {
                 let a = Owned::new(7).into_shared(guard);
                 guard.defer(move || a.into_owned());
 
-                assert!(!(*(*guard.local).bag.get()).is_empty());
+                assert!(!(*guard.get_local()).is_bag_empty());
 
-                while !(*(*guard.local).bag.get()).is_empty() {
+                while !(*guard.get_local()).is_bag_empty() {
                     guard.flush();
                 }
             }
@@ -149,7 +149,7 @@ mod tests {
                 let a = Owned::new(7).into_shared(guard);
                 guard.defer(move || a.into_owned());
             }
-            assert!(!(*(*guard.local).bag.get()).is_empty());
+            assert!(!(*guard.get_local()).is_bag_empty());
         }
     }
 
@@ -165,9 +165,9 @@ mod tests {
                         for _ in 0..500_000 {
                             let guard = &handle.pin();
 
-                            let before = collector.global.epoch.load(Ordering::Relaxed);
+                            let before = collector.global.load_epoch(Ordering::Relaxed);
                             collector.global.collect(guard);
-                            let after = collector.global.epoch.load(Ordering::Relaxed);
+                            let after = collector.global.load_epoch(Ordering::Relaxed);
 
                             assert!(after.wrapping_sub(before) <= 2);
                         }

--- a/src/deferred.rs
+++ b/src/deferred.rs
@@ -37,7 +37,7 @@ impl Deferred {
 
                 Deferred {
                     call: call::<F>,
-                    data,
+                    data: data,
                 }
             } else {
                 let b: Box<F> = Box::new(f);
@@ -51,7 +51,7 @@ impl Deferred {
 
                 Deferred {
                     call: call::<F>,
-                    data,
+                    data: data,
                 }
             }
         }

--- a/src/epoch.rs
+++ b/src/epoch.rs
@@ -77,7 +77,7 @@ impl AtomicEpoch {
     #[inline]
     pub fn new(epoch: Epoch) -> Self {
         let data = AtomicUsize::new(epoch.data);
-        AtomicEpoch { data }
+        AtomicEpoch { data: data }
     }
 
     /// Loads a value from the atomic epoch.
@@ -101,6 +101,6 @@ impl AtomicEpoch {
     #[inline]
     pub fn compare_and_swap(&self, current: Epoch, new: Epoch, ord: Ordering) -> Epoch {
         let data = self.data.compare_and_swap(current.data, new.data, ord);
-        Epoch { data }
+        Epoch { data: data }
     }
 }

--- a/src/garbage.rs
+++ b/src/garbage.rs
@@ -92,7 +92,7 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT};
     use std::sync::atomic::Ordering;
 
-    use super::*;
+    use super::{Garbage, Bag};
 
     #[test]
     fn check_defer() {
@@ -117,7 +117,7 @@ mod tests {
         let mut bag = Bag::new();
         assert!(bag.is_empty());
 
-        for _ in 0..MAX_OBJECTS {
+        for _ in 0..super::MAX_OBJECTS {
             assert!(bag.try_push(Garbage::new(incr)).is_ok());
             assert!(!bag.is_empty());
             assert_eq!(FLAG.load(Ordering::Relaxed), 0);
@@ -129,6 +129,6 @@ mod tests {
         assert_eq!(FLAG.load(Ordering::Relaxed), 0);
 
         drop(bag);
-        assert_eq!(FLAG.load(Ordering::Relaxed), MAX_OBJECTS);
+        assert_eq!(FLAG.load(Ordering::Relaxed), super::MAX_OBJECTS);
     }
 }

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -19,14 +19,12 @@
 use core::cell::{Cell, UnsafeCell};
 use core::mem;
 use core::num::Wrapping;
-use core::ptr;
 use core::sync::atomic;
 use core::sync::atomic::Ordering;
 use alloc::boxed::Box;
 use alloc::arc::Arc;
 
 use crossbeam_utils::cache_padded::CachePadded;
-use nodrop::NoDrop;
 
 use atomic::Owned;
 use epoch::{AtomicEpoch, Epoch};
@@ -172,7 +170,7 @@ pub struct Local {
     /// A reference to the global data.
     ///
     /// When all guards and handles get dropped, this reference is destroyed.
-    global: UnsafeCell<NoDrop<Arc<Global>>>,
+    global: UnsafeCell<Option<Arc<Global>>>,
 
     /// The local bag of deferred functions.
     bag: UnsafeCell<Bag>,
@@ -200,7 +198,7 @@ impl Local {
             let local = Owned::new(Local {
                 entry: Entry::default(),
                 epoch: AtomicEpoch::new(Epoch::starting()),
-                global: UnsafeCell::new(NoDrop::new(global.clone())),
+                global: UnsafeCell::new(Some(global.clone())),
                 bag: UnsafeCell::new(Bag::new()),
                 guard_count: Cell::new(0),
                 handle_count: Cell::new(1),
@@ -220,7 +218,7 @@ impl Local {
     /// Returns a reference to the `Global` in which this `Local` resides.
     #[inline]
     pub fn global(&self) -> &Global {
-        unsafe { &*self.global.get() }
+        unsafe { (&*self.global.get()).as_ref().unwrap() }
     }
 
     /// Returns `true` if the current participant is pinned.
@@ -376,7 +374,7 @@ impl Local {
             // Take the reference to the `Global` out of this `Local`. Since we're not protected
             // by a guard at this time, it's crucial that the reference is read before marking the
             // `Local` as deleted.
-            let global: Arc<Global> = ptr::read(&**self.global.get());
+            let global: Arc<Global> = (&mut *self.global.get()).take().unwrap();
 
             // Mark this node in the linked list as deleted.
             self.entry.delete(&unprotected());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,13 @@ mod alloc {
     pub use self::std::sync as arc;
 }
 
+#[cfg(feature = "manually_drop")]
+mod nodrop {
+    pub use std::mem::ManuallyDrop as NoDrop;
+}
+#[cfg(not(feature = "manually_drop"))]
+extern crate nodrop;
+
 extern crate arrayvec;
 extern crate crossbeam_utils;
 #[cfg(feature = "use_std")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,13 +75,6 @@ mod alloc {
     pub use self::std::sync as arc;
 }
 
-#[cfg(feature = "manually_drop")]
-mod nodrop {
-    pub use std::mem::ManuallyDrop as NoDrop;
-}
-#[cfg(not(feature = "manually_drop"))]
-extern crate nodrop;
-
 extern crate arrayvec;
 extern crate crossbeam_utils;
 #[cfg(feature = "use_std")]

--- a/src/sync/list.rs
+++ b/src/sync/list.rs
@@ -130,8 +130,8 @@ pub enum IterError {
 
 impl Default for Entry {
     /// Returns the empty entry.
-    fn default() -> Self {
-        Self { next: Atomic::null() }
+    fn default() -> Entry {
+        Entry { next: Atomic::null() }
     }
 }
 
@@ -150,8 +150,8 @@ impl Entry {
 
 impl<T, C: IsElement<T>> List<T, C> {
     /// Returns a new, empty linked list.
-    pub fn new() -> Self {
-        Self {
+    pub fn new() -> List<T, C> {
+        List {
             head: Atomic::null(),
             _marker: PhantomData,
         }
@@ -204,7 +204,7 @@ impl<T, C: IsElement<T>> List<T, C> {
     ///    thread will continue to iterate over the same list.
     pub fn iter<'g>(&'g self, guard: &'g Guard) -> Iter<'g, T, C> {
         Iter {
-            guard,
+            guard: guard,
             pred: &self.head,
             curr: self.head.load(Acquire, guard),
             head: &self.head,
@@ -289,7 +289,7 @@ impl<'g, T: 'g, C: IsElement<T>> Iterator for Iter<'g, T, C> {
 
 #[cfg(test)]
 mod tests {
-    use {Collector, Owned};
+    use {Collector, Owned, Guard};
     use crossbeam_utils::scoped;
     use std::sync::Barrier;
     use super::*;

--- a/src/sync/queue.rs
+++ b/src/sync/queue.rs
@@ -11,6 +11,7 @@ use core::ptr;
 use core::sync::atomic::Ordering::{Acquire, Relaxed, Release};
 
 use crossbeam_utils::cache_padded::CachePadded;
+use nodrop::NoDrop;
 
 use {unprotected, Atomic, Guard, Owned, Shared};
 
@@ -30,7 +31,7 @@ struct Node<T> {
     /// example, the sentinel node in a queue never contains a value: its slot is always empty.
     /// Other nodes start their life with a push operation and contain a value until it gets popped
     /// out. After that such empty nodes get added to the collector for destruction.
-    data: Option<T>,
+    data: NoDrop<T>,
 
     next: Atomic<Node<T>>,
 }
@@ -38,12 +39,6 @@ struct Node<T> {
 impl<T> fmt::Debug for Node<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         write!(f, "node {{ ... }}")
-    }
-}
-
-impl<T> Drop for Node<T> {
-    fn drop(&mut self) {
-        mem::forget(self.data.take());
     }
 }
 
@@ -98,7 +93,7 @@ impl<T> Queue<T> {
     /// Adds `t` to the back of the queue, possibly waking up threads blocked on `pop`.
     pub fn push(&self, t: T, guard: &Guard) {
         let new = Owned::new(Node {
-            data: Some(t),
+            data: NoDrop::new(t),
             next: Atomic::null(),
         });
         let new = Owned::into_shared(new, guard);
@@ -126,7 +121,7 @@ impl<T> Queue<T> {
                     .compare_and_set(head, next, Release, guard)
                     .map(|_| {
                         guard.defer(move || drop(head.into_owned()));
-                        Some(ptr::read(&n.data).unwrap())
+                        Some(NoDrop::into_inner(ptr::read(&n.data)))
                     })
                     .map_err(|_| ())
             },
@@ -146,12 +141,12 @@ impl<T> Queue<T> {
         let h = unsafe { head.deref() };
         let next = h.next.load(Acquire, guard);
         match unsafe { next.as_ref() } {
-            Some(n) if condition(n.data.as_ref().unwrap()) => unsafe {
+            Some(n) if condition(&n.data) => unsafe {
                 self.head
                     .compare_and_set(head, next, Release, guard)
                     .map(|_| {
                         guard.defer(move || drop(head.into_owned()));
-                        Some(ptr::read(&n.data).unwrap())
+                        Some(NoDrop::into_inner(ptr::read(&n.data)))
                     })
                     .map_err(|_| ())
             },


### PR DESCRIPTION
Likely to clos.. #57.  We have a chance that Rayon's minimum required Rust version can be bumped to 1.14.0.

Funny that I cannot use the right word above and here: it will clos.. #57!