### PR TITLE
Allow extracting a &Collector from a Guard

### DIFF
--- a/src/default.rs
+++ b/src/default.rs
@@ -38,3 +38,9 @@ pub fn is_pinned() -> bool {
 pub fn default_handle() -> Handle {
     HANDLE.with(|handle| handle.clone())
 }
+
+/// Returns the default handle associated with the current thread.
+#[inline]
+pub fn default_collector() -> &'static Collector {
+    &COLLECTOR
+}

--- a/src/guard.rs
+++ b/src/guard.rs
@@ -4,6 +4,7 @@ use core::mem;
 
 use garbage::Garbage;
 use internal::Local;
+use collector::Collector;
 
 /// A guard that keeps the current thread pinned.
 ///
@@ -284,6 +285,28 @@ impl Guard {
         }
 
         f()
+    }
+
+    /// Returns the `Collector` associated with this guard.
+    ///
+    /// This method is useful when you need to ensure that all guards used with
+    /// a data structure come from the same collector.
+    ///
+    /// If this method is called from an [`unprotected`] guard, then `None` is returned.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use crossbeam_epoch as epoch;
+    ///
+    /// let mut guard1 = epoch::pin();
+    /// let mut guard2 = epoch::pin();
+    /// assert!(guard1.collector() == guard2.collector());
+    /// ```
+    ///
+    /// [`unprotected`]: fn.unprotected.html
+    pub fn collector(&self) -> Option<&Collector> {
+        unsafe { self.local.as_ref().map(|local| local.collector()) }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,11 +58,11 @@
 #![cfg_attr(feature = "nightly", feature(alloc))]
 #![cfg_attr(not(test), no_std)]
 
+#[cfg(test)]
+extern crate core;
 #[cfg(all(not(test), feature = "use_std"))]
 #[macro_use]
 extern crate std;
-#[cfg(test)]
-extern crate core;
 
 // Use liballoc on nightly to avoid a dependency on libstd
 #[cfg(feature = "nightly")]
@@ -99,5 +99,5 @@ mod sync;
 pub use self::atomic::{Atomic, CompareAndSetError, CompareAndSetOrdering, Owned, Shared};
 pub use self::guard::{unprotected, Guard};
 #[cfg(feature = "use_std")]
-pub use self::default::{default_handle, is_pinned, pin};
+pub use self::default::{default_collector, default_handle, is_pinned, pin};
 pub use self::collector::{Collector, Handle};


### PR DESCRIPTION
This is needed for https://github.com/crossbeam-rs/crossbeam-skiplist/issues/4