### PR TITLE
Update for latest nightly

### DIFF
--- a/src/collector.rs
+++ b/src/collector.rs
@@ -13,7 +13,7 @@
 /// handle.pin().flush();
 /// ```
 
-use alloc::arc::Arc;
+use alloc::sync::Arc;
 use core::fmt;
 
 use internal::{Global, Local};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,12 +70,7 @@ extern crate std;
 #[cfg(feature = "nightly")]
 extern crate alloc;
 #[cfg(not(feature = "nightly"))]
-mod alloc {
-    // Tweak the module layout to match the one in liballoc
-    extern crate std;
-    pub use self::std::boxed;
-    pub use self::std::sync as arc;
-}
+extern crate std as alloc;
 
 extern crate arrayvec;
 extern crate crossbeam_utils;


### PR DESCRIPTION
The layout of the `alloc` crate has changed to match the layout of `std`.